### PR TITLE
fix: add debugging to Docker image test step

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -130,10 +130,17 @@ jobs:
           docker buildx imagetools inspect localhost:5000/foobar/${{ env.IMAGE_NAME }}
       - name: Test the Docker image
         run: |
-          CONTAINER_OUTPUT=$(docker run --rm -t localhost:5000/foobar/${{ env.IMAGE_NAME }} nginx -v)
-          # shellcheck disable=SC2086
-          TEST_STRING=$(echo ${CONTAINER_OUTPUT} | head -1 | cut -d' ' -f1)
-          if ! [ "${TEST_STRING}" = "nginx" ]; then exit 1; fi
+          CONTAINER_OUTPUT=$(docker run --rm localhost:5000/foobar/${{ env.IMAGE_NAME }} nginx -v 2>&1 | head -1)
+          echo "Container output: $CONTAINER_OUTPUT"
+          echo "Container output (quoted): '$CONTAINER_OUTPUT'"
+
+          TEST_STRING=$(echo "${CONTAINER_OUTPUT}" | head -1 | cut -d' ' -f1)
+          echo "Extracted test string: '$TEST_STRING'"
+
+          if ! [ "${TEST_STRING}" = "nginx" ]; then
+            echo "ERROR: Expected 'nginx' but got '$TEST_STRING'"
+            exit 1
+          fi
   dockle:
     name: Run Dockle tests
     needs:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Enhance the Docker image test step in the workflow to print container output and detailed error messages when the nginx check fails.